### PR TITLE
Fix errorStrategy: update access method to maxRetries directive value

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -81,7 +81,7 @@ workflow.output.mode = params.file_publish
 // Set auto-retry and process container images
 process {
     maxRetries = 2
-    errorStrategy = { task.attempt <= process.maxRetries ? 'retry' : 'ignore' }
+    errorStrategy = { task.attempt <= task.maxRetries ? 'retry' : 'ignore' }
 
     withLabel: bash_container {
         container = 'wbitt/network-multitool:3.22.2'


### PR DESCRIPTION
`process.maxRetries` can no longer be resolved within `errorStrategy` in the latest Nextflow, causing error and pipeline termination if a process encounters an error. 

It seems the proper way to access `maxRetries` is via `task.maxRetries` according to [Nextflow documentations](https://docs.seqera.io/nextflow/reference/process/task-properties)
> [Directive values](https://docs.seqera.io/nextflow/reference/process/directives) for a task can be accessed as `task.<directive>`. See [Task directive values](https://docs.seqera.io/nextflow/process#using-task-directive-values) for more information.